### PR TITLE
convert utility function evaluation to use a js evaluator in python

### DIFF
--- a/configs/round_configs/demo.yaml
+++ b/configs/round_configs/demo.yaml
@@ -21,9 +21,9 @@ trade_box_scale: 0.2
 
 # function for calculating utility given a player's current x and y holdings
 # this calculation is done after scaling, so x and y are fractional values
-# this function needs to be both valid javascript and python code which means available operations are
-# pretty much just limited to arithmetic
-utility_function: "(x ** 0.5) * (y ** 0.5)"
+# this function has to be valid javascript (pre es6, meaning no '**' operator)
+# all of the Math functions are available though
+utility_function: "Math.sqrt(x) * Math.sqrt(y)"
 # the maximum utility value which can be reached by a player
 # this is used to scale displayed utility values when generating the heatmap
 max_utility: 50

--- a/models.py
+++ b/models.py
@@ -6,6 +6,8 @@ from otree_markets.exchange.base import Order, OrderStatusEnum
 from .configmanager import MarketConfig
 import itertools
 
+import js2py
+
 
 class Constants(BaseConstants):
     name_in_url = 'otree_visual_markets'
@@ -135,8 +137,8 @@ class Player(markets_models.Player):
         return MarketConfig.get(config_name, self.round_number, self.id_in_group)
     
     def utility_function(self, x, y):
-        return eval(self.config.utility_function, {'x': x, 'y': y})
-    
+        return js2py.eval_js('function $(x, y) { return ' + self.config.utility_function + '; }')(x, y)
+
     def set_payoff(self):
         config = self.config
 


### PR DESCRIPTION
this means the utility function definition no longer needs to be valid as both js and python. it now only needs to be valid as js. this allows more complex utility functions using things like Math and ternary operators.